### PR TITLE
Switch from githubOrg to gitUrlPrefix to handle any git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,17 @@ this repository and illustrates each of the following settings:
     the host machine
   * **bucket**: address of the S3 bucket to which to sync generated sites
 * **payloadLimit**: maximum allowable size (in bytes) for incoming webhooks
-* **githubOrg**: GitHub organization to which all published repositories
-  belong
+* **gitUrlPrefix**: the prefix used to build `git` URLs when cloning a
+  repository. This will be something like:
+  ```
+  GitHub: git@github.com:<USERNAME-OR-ORGANIZATION>
+  Bitbucket/SSH: ssh://git@<BITBUCKET-HOST>:<BITBUCKET-PORT>/<BITBUCKET-PROJECT>
+  ```
+  For example:
+  ```
+  GitHub: git@github.com:mbland/guides
+  Bitbucket/SSH: ssh://git@repo-host:8080/GUIDES
+  ```
 * **pagesConfig**: name of the [server-generated Jekyll config file](#generated-config)
   that sets the `baseurl:`Jekyll property
 * **pagesYaml**: name of the file from which properties such as `baseurl:`
@@ -266,7 +275,7 @@ this repository and illustrates each of the following settings:
 Also, each `builders` entry may override one or more of the following
 top-level values:
 
-* **githubOrg**
+* **gitUrlPrefix**
 * **pagesConfig**
 * **pagesYaml**
 * **secretKeyFile**

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function doLaunch(config, keyDictionary) {
 
   console.log(exports.versionString());
   var server = webhook.listen(config.port);
-  console.log(config.githubOrg + ' pages: listening on port ' +
+  console.log(config.gitUrlPrefix + ' pages: listening on port ' +
     server.address().port);
   return server;
 }

--- a/lib/git-runner.js
+++ b/lib/git-runner.js
@@ -6,7 +6,7 @@ module.exports = GitRunner;
 
 function GitRunner(config, builderOpts, commandRunner, logger) {
   this.git = config.git;
-  this.githubOrg = builderOpts.githubOrg;
+  this.gitUrlPrefix = builderOpts.gitUrlPrefix;
   this.repoDir = builderOpts.repoDir;
   this.sitePath = builderOpts.sitePath;
   this.commandRunner = commandRunner;
@@ -48,7 +48,7 @@ function syncRepo(gitRunner, branch) {
 }
 
 function cloneRepo(gitRunner, branch) {
-  var cloneAddr = 'git@github.com:' + gitRunner.githubOrg + '/' +
+  var cloneAddr = gitRunner.gitUrlPrefix +
         gitRunner.commandRunner.repoName + '.git',
       cloneArgs = ['clone', cloneAddr, '--branch', branch],
       cloneOpts = { cwd: gitRunner.repoDir },

--- a/lib/options.js
+++ b/lib/options.js
@@ -18,7 +18,7 @@ module.exports = Options;
 //   branch: branch of the Pages repository to check out and rebuild
 //   destDir: input argument prefixed with config.home
 //   internalDestDir: internal documentation destination from builderConfig
-//   githubOrg: from builderConfig or top-level config
+//   gitUrlPrefix: from builderConfig or top-level config
 //   pagesConfig: from builderConfig or top-level config
 //   pagesYaml: from builderConfig or top-level config
 function Options(info, config, builderConfig) {
@@ -34,7 +34,8 @@ function Options(info, config, builderConfig) {
     this.internalDestDir = path.join(
       config.home, builderConfig.internalSiteDir);
   }
-  this.githubOrg = builderConfig.githubOrg || config.githubOrg;
+  this.gitUrlPrefix = builderConfig.gitUrlPrefix || config.gitUrlPrefix;
+  this.gitUrlPrefix += this.gitUrlPrefix.endsWith('/') ? '' : '/';
   this.pagesConfig = builderConfig.pagesConfig || config.pagesConfig;
   this.pagesYaml = builderConfig.pagesYaml || config.pagesYaml;
 

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -14,6 +14,12 @@ SiteBuilder.setConfiguration = function(configuration) {
   config = configuration;
 };
 
+// Parses the last component from gitUrlPrefix, which represents either a
+// username, organization, or project.
+SiteBuilder.parentFromGitUrlPrefix = function(gitUrlPrefix) {
+  return gitUrlPrefix.replace(/\/$/, '').split(/[:/]/).pop();
+};
+
 // Executes the algorithm for cloning/syncing repos and publishing sites.
 // Patterned after the ControlFlow pattern used within Google.
 //
@@ -198,12 +204,11 @@ function removeLog(sourceLog) {
 
 // TODO(mbland): Extract into factory.
 SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
-  var org = builderConfig.githubOrg || config.githubOrg,
+  var org = SiteBuilder.parentFromGitUrlPrefix(
+        builderConfig.gitUrlPrefix || config.gitUrlPrefix),
       branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
-      branchRegexp,
+      branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$'),
       handler;
-
-  branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$');
 
   handler = function(info) {
     var branch = branchRegexp.exec(info.ref);

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -196,6 +196,7 @@ function removeLog(sourceLog) {
   });
 }
 
+// TODO(mbland): Extract into factory.
 SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
   var org = builderConfig.githubOrg || config.githubOrg,
       branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,

--- a/pages-config.json
+++ b/pages-config.json
@@ -17,7 +17,7 @@
     "bucket":  "s3://pages"
   },
   "payloadLimit":     1048576,
-  "githubOrg":        "mbland",
+  "gitUrlPrefix":     "git@github.com:mbland",
   "pagesConfig":      "_config_pages.yml",
   "pagesYaml":        ".pages.yml",
   "fileLockWaitTime": 30000,

--- a/test/git-runner-test.js
+++ b/test/git-runner-test.js
@@ -20,8 +20,11 @@ describe('GitRunner', function() {
   before(function() {
     config = JSON.parse(JSON.stringify(pagesConfig));
     config.git = 'git';
+
+    // Add the trailing slash manually here, since the GitRunner expects the
+    // Options object already added one if needed.
     opts = {
-      githubOrg: 'mbland',
+      gitUrlPrefix: 'git@github.com:mbland/',
       repoDir: 'repo_dir',
       repoName: 'repo_name'
     };

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ var config = {
   'rsync':            'rsync',
   'rsyncOpts':        ['-vaxp', '--delete', '--ignore-errors'],
   'payloadLimit':     1048576,
-  'githubOrg':        'mbland',
+  'gitUrlPrefix':     'git@github.com:mbland',
   'pagesConfig':      '_config_mbland_pages.yml',
   'fileLockWaitTime': 30000,
   'fileLockPollTime': 1000,

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -38,7 +38,7 @@ describe('Options', function() {
     expect(opts.branch).to.equal('mbland-pages');
     expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'));
     expect(opts.internalDestDir).to.be.undefined;
-    expect(opts.githubOrg).to.equal('mbland');
+    expect(opts.gitUrlPrefix).to.equal('git@github.com:mbland/');
     expect(opts.pagesConfig).to.equal('_config_pages.yml');
   });
 
@@ -50,8 +50,9 @@ describe('Options', function() {
       ref: 'refs/heads/foobar-pages'
     };
 
+    // Here we're also testing that we don't add an extra slash to gitUrlPrefix.
     var builderConfig = {
-      'githubOrg': 'foobar',
+      'gitUrlPrefix': 'git@github.com:foobar/',
       'pagesConfig': '_config_foobar_pages.yml',
       'pagesYaml': '.mbland-pages.yml',
       'branch': 'foobar-pages',
@@ -68,7 +69,7 @@ describe('Options', function() {
     expect(opts.branch).to.equal('foobar-pages');
     expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'));
     expect(opts.internalDestDir).to.be.undefined;
-    expect(opts.githubOrg).to.equal('foobar');
+    expect(opts.gitUrlPrefix).to.equal('git@github.com:foobar/');
     expect(opts.pagesConfig).to.equal('_config_foobar_pages.yml');
     expect(opts.pagesYaml).to.equal('.mbland-pages.yml');
     expect(opts.branchInUrlPattern.toString()).to.equal(

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -79,6 +79,18 @@ describe('SiteBuilder', function() {
     expect(consoleMessages).to.eql(expected);
   };
 
+  describe('parentFromGitUrlPrefix', function() {
+    it('should get a git@github.org user or org', function() {
+      expect(SiteBuilder.parentFromGitUrlPrefix('git@github.com:mbland/'))
+        .to.equal('mbland');
+    });
+
+    it('should get a https://github.org user or org', function() {
+      expect(SiteBuilder.parentFromGitUrlPrefix('https://github.com/mbland/'))
+        .to.equal('mbland');
+    });
+  });
+
   describe('build', function() {
     var builder, buildConfigs;
 


### PR DESCRIPTION
This is the first step towards supporting other repository systems than GitHub, most notably Bitbucket. At this point, the entire system can handle generic git URLs, but the only type of webhook supported at the moment is GitHub.

Note that this is a breaking change, but it's trivial to convert an `githubOrg` by adding a `git@github.org:` prefix.