### PR TITLE
Remove command paths from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,17 +226,11 @@ this repository and illustrates each of the following settings:
 
 * **port**: the port on which the server will listen for GitHub webhooks
 * **home**: the parent directory for all of the generated site content
-* **git**:  path to `git` on the host machine
-* **bundler**: path to `bundle` on the host machine
 * **bundlerCacheDir**: path to bundle cache relative to **home**
-* **jekyll**:  path to `jekyll` on the host machine
-* **rsync**: path to `rsync` on the host machine
 * **rsyncOpts**: options to pass to `rsync` that control Jekyll-less builds;
   OS X installations in particular may need to adjust these
 * **s3 (optional)**: if present, will back up each generated site to
   [Amazon S3](https://aws.amazon.com/s3/); attributes are:
-  * **awscli**: path to the [`aws` command](https://aws.amazon.com/cli/) on
-    the host machine
   * **bucket**: address of the S3 bucket to which to sync generated sites
 * **payloadLimit**: maximum allowable size (in bytes) for incoming webhooks
 * **gitUrlPrefix**: the prefix used to build `git` URLs when cloning a

--- a/lib/git-runner.js
+++ b/lib/git-runner.js
@@ -5,7 +5,6 @@ var fs = require('fs')
 module.exports = GitRunner
 
 function GitRunner(config, builderOpts, commandRunner, logger) {
-  this.git = config.git
   this.gitUrlPrefix = builderOpts.gitUrlPrefix
   this.repoDir = builderOpts.repoDir
   this.sitePath = builderOpts.sitePath
@@ -26,24 +25,22 @@ GitRunner.prototype.prepareRepo = function(branch) {
 }
 
 function syncRepo(gitRunner, branch) {
-  var commandRunner = gitRunner.commandRunner,
-      git = gitRunner.git
+  var commandRunner = gitRunner.commandRunner
 
   gitRunner.logger.log('syncing repo:', commandRunner.repoName)
-  return commandRunner.run(git, ['fetch', 'origin', branch])
+  return commandRunner.run('git', ['fetch', 'origin', branch])
     .then(function() {
-      return commandRunner.run(git, ['clean', '-f'])
+      return commandRunner.run('git', ['clean', '-f'])
     })
     .then(function() {
-      return commandRunner.run(git, ['reset', '--hard', 'origin/' + branch])
+      return commandRunner.run('git', ['reset', '--hard', 'origin/' + branch])
+    })
+    .then(function() {
+      return commandRunner.run('git', ['submodule', 'sync', '--recursive'])
     })
     .then(function() {
       return commandRunner.run(
-        git, ['submodule', 'sync', '--recursive'])
-    })
-    .then(function() {
-      return commandRunner.run(
-        git, ['submodule', 'update', '--init', '--recursive'])
+        'git', ['submodule', 'update', '--init', '--recursive'])
     })
 }
 
@@ -56,6 +53,5 @@ function cloneRepo(gitRunner, branch) {
 
   gitRunner.logger.log('cloning', gitRunner.commandRunner.repoName,
     'into', gitRunner.commandRunner.sitePath)
-  return gitRunner.commandRunner.run(
-    gitRunner.git, cloneArgs, cloneOpts, errMsg)
+  return gitRunner.commandRunner.run('git', cloneArgs, cloneOpts, errMsg)
 }

--- a/lib/jekyll-command-helper.js
+++ b/lib/jekyll-command-helper.js
@@ -3,8 +3,6 @@
 module.exports = JekyllCommandHelper
 
 function JekyllCommandHelper(config, commandRunner) {
-  this.jekyll = config.jekyll
-  this.bundler = config.bundler
   this.commandRunner = commandRunner
   this.args = ['build', '--trace', '--destination']
 }
@@ -22,13 +20,13 @@ JekyllCommandHelper.prototype.build = function(buildConfigurations, opts) {
 }
 
 function runBuild(helper, destination, opts, configs) {
-  var command = helper.jekyll,
+  var command = 'jekyll',
       args
 
   args = helper.args.concat(destination).concat('--config').concat(configs)
 
   if (opts.bundler) {
-    command = helper.bundler
+    command = 'bundle'
     args = ['exec', 'jekyll'].concat(args)
   }
   return helper.commandRunner.run(command, args)

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -49,9 +49,8 @@ SiteBuilder.prototype.build = function() {
       })
       .then(function() {
         if (builder.configHandler.usesBundler) {
-          return builder.commandRunner.run(
-            config.bundler, ['install',
-              '--path=' + path.join(config.home, config.bundlerCacheDir)])
+          return builder.commandRunner.run('bundle', ['install',
+            '--path=' + path.join(config.home, config.bundlerCacheDir)])
         }
       })
       .then(function() {
@@ -85,7 +84,7 @@ function rsync(builder) {
 
 function generateRsyncOp(builder, previousRsync, buildConfig) {
   return previousRsync.then(function() {
-    return builder.commandRunner.run(config.rsync,
+    return builder.commandRunner.run('rsync',
       config.rsyncOpts.concat(['./', buildConfig.destination]))
   })
 }

--- a/pages-config.json
+++ b/pages-config.json
@@ -1,11 +1,7 @@
 {
   "port":             5000,
   "home":             "/opt/pages-server/data",
-  "git":              "/usr/bin/git",
-  "bundler":          "/opt/rbenv/shims/bundle",
   "bundlerCacheDir":  "bundler-cache",
-  "jekyll":           "/opt/rbenv/shims/jekyll",
-  "rsync":            "/usr/bin/rsync",
   "rsyncOpts":        [
     "-vaxp",
     "--delete",

--- a/test/git-runner-test.js
+++ b/test/git-runner-test.js
@@ -19,7 +19,6 @@ describe('GitRunner', function() {
 
   before(function() {
     config = JSON.parse(JSON.stringify(pagesConfig))
-    config.git = 'git'
 
     // Add the trailing slash manually here, since the GitRunner expects the
     // Options object already added one if needed.

--- a/test/jekyll-command-helper-test.js
+++ b/test/jekyll-command-helper-test.js
@@ -15,8 +15,6 @@ describe('JekyllCommandHelper', function() {
 
   before(function() {
     config = JSON.parse(JSON.stringify(pagesConfig))
-    config.jekyll = 'jekyll'
-    config.bundler = 'bundle'
     commandRunner = new CommandRunner()
     internalConfig = {
       destination: path.join('internal/deploy/dir'),

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -24,11 +24,7 @@ describe('SiteBuilder', function() {
 
   function cloneConfig() {
     config = JSON.parse(JSON.stringify(OrigConfig))
-    config.git = 'git'
-    config.bundler = 'bundle'
     config.bundlerCacheDir = 'bundler_cache_dir'
-    config.jekyll = 'jekyll'
-    config.rsync = 'rsync'
   }
 
   before(function() {
@@ -145,7 +141,7 @@ describe('SiteBuilder', function() {
           builder.gitRunner.prepareRepo.args.should.eql([[builder.branch]])
           builder.configHandler.init.called.should.be.true
           builder.commandRunner.run.args.should.eql([
-            [config.bundler,
+            ['bundle',
               ['install',
                 '--path=' + path.join(config.home, config.bundlerCacheDir)]]
           ])
@@ -171,7 +167,7 @@ describe('SiteBuilder', function() {
           builder.gitRunner.prepareRepo.args.should.eql([[builder.branch]])
           builder.configHandler.init.called.should.be.true
           builder.commandRunner.run.args.should.eql([
-            [config.rsync, config.rsyncOpts.concat(['./', buildDestination])]
+            ['rsync', config.rsyncOpts.concat(['./', buildDestination])]
           ])
           builder.sync.sync.args.should.eql([[buildDestination]])
           builder.configHandler.readOrWriteConfig.called.should.be.false


### PR DESCRIPTION
These fields served to make the configuration more brittle and verbose. In the time of Docker containers, these programs should be tightly controlled at the container level anyway.