### PR TITLE
Make completely generic webhooks.createHandler

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -14,12 +14,6 @@ SiteBuilder.setConfiguration = function(configuration) {
   config = configuration
 }
 
-// Parses the last component from gitUrlPrefix, which represents either a
-// username, organization, or project.
-SiteBuilder.parentFromGitUrlPrefix = function(gitUrlPrefix) {
-  return gitUrlPrefix.replace(/\/$/, '').split(/[:/]/).pop()
-}
-
 // Executes the algorithm for cloning/syncing repos and publishing sites.
 // Patterned after the ControlFlow pattern used within Google.
 //
@@ -199,25 +193,4 @@ function removeLog(sourceLog) {
       return err ? reject(err) : resolve()
     })
   })
-}
-
-SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
-  var org = SiteBuilder.parentFromGitUrlPrefix(
-        builderConfig.gitUrlPrefix || config.gitUrlPrefix),
-      branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
-      branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$'),
-      handler
-
-  handler = function(info) {
-    var branch = branchRegexp.exec(info.ref)
-
-    if (branch && (info.repository.organization === org)) {
-      return SiteBuilder.launchBuilder(info, branch[1], builderConfig)
-    } else {
-      return Promise.resolve()
-    }
-  }
-  webhook.on('create', handler)
-  webhook.on('push', handler)
-  return handler
 }

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,11 +1,19 @@
 'use strict'
 
 var SiteBuilder = require('./site-builder')
-var express = require('express')
-var bodyParser = require('body-parser')
 
 exports = module.exports = {}
 
+// Parses the last component from gitUrlPrefix, which represents either a
+// username, organization, or project.
+exports.parentFromGitUrlPrefix = function(gitUrlPrefix) {
+  return gitUrlPrefix.replace(/\/$/, '').split(/[:/]/).pop().toLowerCase()
+}
+
+// Returns a new instance of a webhook implementation object.
+//
+// `webhookType` must match one of the module names in `lib/webhooks`; not case
+// sensitive.
 exports.createImpl = function(webhookType) {
   try {
     var Impl = require('./webhooks/' + (webhookType || 'github').toLowerCase())
@@ -15,26 +23,11 @@ exports.createImpl = function(webhookType) {
   }
 }
 
-exports.createListener = function(webhookImpl, parserOpts, config) {
-  var webhook = express()
-
-  webhook.use(bodyParser.json(parserOpts))
-  webhook.post('/', function(req, res) {
-    if (webhookImpl.isValidWebhook(req.body)) {
-      webhook.emit('hook', req.body)
-      res.sendStatus(202)
-    } else {
-      res.sendStatus(400)
-    }
-  })
-  config.builders.forEach(function(builder) {
-    webhook.on('hook', createBuilder(webhookImpl, config, builder))
-  })
-  return webhook.listen(config.port)
-}
-
-function createBuilder(webhookImpl, config, builderConfig) {
-  var parent = SiteBuilder.parentFromGitUrlPrefix(
+// Returns a function that builds webhooks matching the configuration
+//
+// Values in `builderConfig` will override default values in `config`.
+exports.createBuilder = function(webhookImpl, config, builderConfig) {
+  var parent = exports.parentFromGitUrlPrefix(
         builderConfig.gitUrlPrefix || config.gitUrlPrefix),
       branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
       branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$')
@@ -48,4 +41,36 @@ function createBuilder(webhookImpl, config, builderConfig) {
       return Promise.resolve()
     }
   }
+}
+
+// Runs all builders matching a valid webhook
+//
+// If the webhook is valid, send will receive a 202 (Accepted) status, and the
+// function will return a Promise that resolves when all matching builders are
+// finished.
+//
+// Otherwise `send` will receive a 400 (Bad Request) status, and the function
+// returns an empty resolved Promise.
+exports.handleWebhook = function(hook, impl, builders, send) {
+  if (!impl.isValidWebhook(hook)) {
+    send(400)
+    return Promise.resolve()
+  }
+  send(202)
+  return Promise.all(builders.map(builder => builder(hook)))
+}
+
+// Returns a (hook, send) that will respond to hooks matching the configuration
+//
+// Instantiates a webhook implementation and generates a list of builders based
+// on `config` for the returned closure.
+//
+// The `send` argument and returned Promises are identical to those from
+// `handleWebhook`.
+exports.createHandler = function(config) {
+  var impl = exports.createImpl(config.webhookType),
+      builders = config.builders.map(builder => {
+        return exports.createBuilder(impl, config, builder)
+      })
+  return (hook, send) => exports.handleWebhook(hook, impl, builders, send)
 }

--- a/lib/webhooks/bitbucket.js
+++ b/lib/webhooks/bitbucket.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = BitbucketWebhook
+
+function BitbucketWebhook() {
+}
+
+BitbucketWebhook.prototype.isValidWebhook = function(hook) {
+  return hook.refChanges !== undefined
+}
+
+BitbucketWebhook.prototype.getBranch = function(hook) {
+  return hook.refChanges.refId
+}
+
+BitbucketWebhook.prototype.getParent = function(hook) {
+  return hook.repository.project.key.toLowerCase()
+}

--- a/pages-config.json
+++ b/pages-config.json
@@ -9,7 +9,6 @@
     "--exclude=.[A-Za-z0-9]*"
   ],
   "s3": {
-    "awscli": "/usr/local/bin/aws",
     "bucket":  "s3://pages"
   },
   "payloadLimit":     1048576,

--- a/pages-config.json
+++ b/pages-config.json
@@ -20,19 +20,19 @@
   "secretKeyFile":    "/opt/pages-server/pages.secret",
   "builders": [
     {
-      "branch":           "mbland-pages",
+      "branch":           "pages",
       "repositoryDir":    "repos/pages.mbland.com",
       "generatedSiteDir": "sites/pages.mbland.com",
       "internalSiteDir":  "sites/pages-internal.mbland.com"
     },
     {
-      "branch":           "mbland-pages-staging",
+      "branch":           "pages-staging",
       "repositoryDir":    "repos/pages-staging.mbland.com",
       "generatedSiteDir": "sites/pages-staging.mbland.com",
       "internalSiteDir":  "sites/pages-internal.mbland.com"
     },
     {
-      "branch":           "mbland-pages-internal",
+      "branch":           "pages-internal",
       "repositoryDir":    "repos/pages-internal.mbland.com",
       "generatedSiteDir": "sites/pages-internal.mbland.com"
     },

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,7 @@ describe('launchServer', function() {
   var server, port, helper
   var origSpawn, mySpawn
   var defaultKey, pagesBranchKey
+  var sendRequest
 
   var captureLogs = function() {
     sinon.stub(console, 'log').returns(null)
@@ -49,6 +50,19 @@ describe('launchServer', function() {
   var restoreLogs = function() {
     console.error.restore()
     console.log.restore()
+  }
+
+  sendRequest = function(options, payload) {
+    captureLogs()
+    return helper.sendRequest(options, payload)
+      .then(result => {
+        restoreLogs()
+        return result
+      })
+      .catch(err => {
+        restoreLogs()
+        throw err
+      })
   }
 
   before(function(done) {
@@ -86,19 +100,19 @@ describe('launchServer', function() {
   it('should make a successful request for mbland-pages', function() {
     var payload = helper.makePayload('mbland-pages')
     var options = helper.httpOptions(port, payload, pagesBranchKey)
-    return helper.sendRequest(options, payload).should.become('Accepted')
+    return sendRequest(options, payload).should.become('Accepted')
   })
 
   it('should make a successful request for master with default', function() {
     var payload = helper.makePayload('master')
     var options = helper.httpOptions(port, payload, defaultKey)
-    return helper.sendRequest(options, payload).should.become('Accepted')
+    return sendRequest(options, payload).should.become('Accepted')
   })
 
   it('should fail a request for mbland-pages with the wrong key', function() {
     var payload = helper.makePayload('mbland-pages')
     var options = helper.httpOptions(port, payload, defaultKey)
-    return helper.sendRequest(options, payload)
+    return sendRequest(options, payload)
       .should.be.rejectedWith('invalid webhook: mbland-pages')
   })
 
@@ -106,7 +120,7 @@ describe('launchServer', function() {
     var payload = helper.makePayload('mbland-pages')
     var options = helper.httpOptions(port, payload, pagesBranchKey)
     delete options.headers['X-Hub-Signature']
-    return helper.sendRequest(options, payload)
+    return sendRequest(options, payload)
       .should.be.rejectedWith('invalid webhook: mbland-pages')
   })
 })

--- a/test/webhooks-test.js
+++ b/test/webhooks-test.js
@@ -1,0 +1,171 @@
+'use strict'
+
+var webhooks = require('../lib/webhooks')
+var SiteBuilder = require('../lib/site-builder')
+var config = require('../pages-config.json')
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
+var sinon = require('sinon')
+
+chai.should()
+chai.use(chaiAsPromised)
+
+describe('Webhooks', function() {
+  var githubImpl = webhooks.createImpl('GitHub'),
+      githubHook = function() {
+        return {
+          repository: { organization: 'mbland' },
+          ref: 'refs/heads/pages'
+        }
+      }
+
+  describe('parentFromGitUrlPrefix', function() {
+    it('should get a git@github.org user or org', function() {
+      webhooks.parentFromGitUrlPrefix('git@github.com:mbland/')
+        .should.equal('mbland')
+    })
+
+    it('should get a https://github.org user or org', function() {
+      webhooks.parentFromGitUrlPrefix('https://github.com/MBland/')
+        .should.equal('mbland')
+    })
+  })
+
+  describe('GitHub impl', function() {
+    var hook
+
+    beforeEach(function() {
+      hook = githubHook()
+    })
+
+    it('should validate a valid webhook', function() {
+      githubImpl.isValidWebhook(hook).should.be.true
+    })
+
+    it('should reject an invalid webhook', function() {
+      delete hook.repository
+      githubImpl.isValidWebhook(hook).should.be.false
+    })
+
+    it('should return the branch name', function() {
+      githubImpl.getBranch(hook).should.equal('refs/heads/pages')
+    })
+
+    it('should return the parent username or organization', function() {
+      githubImpl.getParent(hook).should.equal('mbland')
+    })
+  })
+
+  describe('createBuilder', function() {
+    var builder,
+        builderConfig,
+        hook
+
+    beforeEach(function() {
+      builderConfig = { branch: 'pages' }
+      hook = githubHook()
+      sinon.stub(SiteBuilder, 'launchBuilder').returns(Promise.resolve())
+    })
+
+    afterEach(function() {
+      SiteBuilder.launchBuilder.restore()
+    })
+
+    it('should match config.gitUrlPrefix, branch', function() {
+      builder = webhooks.createBuilder(githubImpl, config, builderConfig)
+      return builder(hook).then(function() {
+        SiteBuilder.launchBuilder.called.should.be.true
+        SiteBuilder.launchBuilder.args[0]
+          .should.eql([hook, 'pages', builderConfig])
+      })
+    })
+
+    it('should ignore hooks that don\'t match exactly', function() {
+      // Note that matching the prefix isn't enough.
+      hook.ref = 'refs/heads/pages-internal'
+      builder = webhooks.createBuilder(githubImpl, config, builderConfig)
+      return builder(hook).then(function() {
+        SiteBuilder.launchBuilder.called.should.be.false
+      })
+    })
+
+    it('should match builderConfig.gitUrlPrefix, branchInUrl', function() {
+      builderConfig.gitUrlPrefix = 'git@github.com:msb'
+      builderConfig.branchInUrlPattern = 'v[0-9]+\\.[0-9]+\\.[0-9]+'
+      hook.repository.organization = 'msb'
+      hook.ref = 'refs/heads/v3.6.9'
+      builder = webhooks.createBuilder(githubImpl, config, builderConfig)
+
+      return builder(hook).then(function() {
+        SiteBuilder.launchBuilder.called.should.be.true
+        SiteBuilder.launchBuilder.args[0]
+          .should.eql([hook, 'v3.6.9', builderConfig])
+      })
+    })
+  })
+
+  describe('handleWebhook', function() {
+    var builders,
+        send
+
+    beforeEach(function() {
+      builders = [sinon.stub(), sinon.stub()]
+      builders.forEach(builder => builder.returns(Promise.resolve()))
+      send = sinon.spy()
+    })
+
+    it('should send 400 Bad Request for an invalid webhook', function() {
+      return webhooks.handleWebhook({}, githubImpl, builders, send)
+        .then(() => {
+          send.calledWith(400).should.be.true
+          builders[0].called.should.be.false
+          builders[1].called.should.be.false
+        })
+    })
+
+    it('should send 202 Accepted for a valid webhook and build OK', function() {
+      return webhooks.handleWebhook(githubHook(), githubImpl, builders, send)
+        .then(() => {
+          send.calledWith(202).should.be.true
+          builders[0].called.should.be.true
+          builders[1].called.should.be.true
+        })
+    })
+
+    it('should send 202 Accepted but fail the build', function() {
+      builders[1].returns(Promise.reject('build failure'))
+      return webhooks.handleWebhook(githubHook(), githubImpl, builders, send)
+        .should.be.rejectedWith('build failure')
+        .then(() => {
+          send.calledWith(202).should.be.true
+          builders[0].called.should.be.true
+          builders[1].called.should.be.true
+        })
+    })
+  })
+
+  describe('createHandler', function() {
+    var send
+
+    beforeEach(function() {
+      sinon.stub(SiteBuilder, 'launchBuilder').returns(Promise.resolve())
+      send = sinon.spy()
+    })
+
+    afterEach(function() {
+      SiteBuilder.launchBuilder.restore()
+    })
+
+    it('should return a handler closure with acces to impl, builders', () => {
+      var handler = webhooks.createHandler(config),
+          hook = githubHook()
+
+      return handler(hook, send).then(() => {
+        send.calledWith(202).should.be.true
+        SiteBuilder.launchBuilder.calledOnce.should.be.true
+        SiteBuilder.launchBuilder.args[0]
+          .should.eql([hook, 'pages', config.builders[0]])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Part of #2 and #13. Not only should it be very straightforward to add a Bitbucket webhook implementation, but it should be very easy to implement an AWS Lambda function based on `webhooks.createHandler` module.

Also:
* removes the vestigial `s3.awscli` configuration field that should've been part of #12, and
* ensures request console output gets captured in `test/index.js; previously, error output from the test cases expecting request failures would get mixed in with the test results.

cc: @akashvbabu