### PR TITLE
Add morgan for logging; log errors to console

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var packageInfo = require('./package.json')
 var webhookValidator = require('github-webhook-validator')
 var express = require('express')
 var bodyParser = require('body-parser')
+var morgan = require('morgan')
 
 var exports = module.exports = {}
 
@@ -43,15 +44,12 @@ function doLaunch(config, keyDictionary) {
   if (keyDictionary !== undefined) {
     parserOpts.verify = webhookValidator.middlewareValidator(keyDictionary)
   }
+  app.use(morgan('combined'))
   app.use(bodyParser.json(parserOpts))
 
-  app.post('/', function(req, res, next) {
+  app.post('/', function(req, res) {
     handler(req.body, status => res.sendStatus(status))
-      .then(() => next())
-      .catch(err => {
-        res.sendStatus(500)
-        next(err)
-      })
+      .catch(err => console.error(err))
   })
 
   server = app.listen(config.port)

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
@@ -491,7 +499,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -534,6 +541,11 @@
         "rimraf": "2.6.2"
       }
     },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -555,6 +567,11 @@
         "esutils": "2.0.2",
         "isarray": "1.0.0"
       }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -1464,11 +1481,22 @@
       "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
       "dev": true
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1535,6 +1563,19 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
@@ -1758,8 +1799,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "file-locked-operation": "^1.0.0",
     "github-webhook-validator": "^0.2.0",
+    "morgan": "^1.9.0",
     "yamljs": "^0.2.4"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -17,10 +17,6 @@ chai.use(chaiAsPromised)
 var config = {
   'port':             0,
   'home':             __dirname,
-  'git':              'git',
-  'bundler':          'bundle',
-  'jekyll':           'jekyll',
-  'rsync':            'rsync',
   'rsyncOpts':        ['-vaxp', '--delete', '--ignore-errors'],
   'payloadLimit':     1048576,
   'gitUrlPrefix':     'git@github.com:mbland',


### PR DESCRIPTION
We could probably improve the error logging, but this will do for now.

Also, the morgan log output gets emitted during the `launchServer` test, but I can't think of a clean way to capture those right now.
