### PR TITLE
Parse GitHub and Bitbucket webhooks into common format

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ this repository and illustrates each of the following settings:
   [Amazon S3](https://aws.amazon.com/s3/); attributes are:
   * **bucket**: address of the S3 bucket to which to sync generated sites
 * **payloadLimit**: maximum allowable size (in bytes) for incoming webhooks
+* **webhookType**: type of webhook to respond to; currently `github` (default)
+  and `bitbucket` are supported.
 * **gitUrlPrefix**: the prefix used to build `git` URLs when cloning a
   repository. This will be something like:
   ```

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,7 +7,7 @@ module.exports = Options
 // Creates an options object to pass to the SiteBuilder constructor
 //
 // Arguments:
-//   info: GitHub webhook payload
+//   hook: GitHub webhook payload
 //   config: full Pages configuration object containing system-wide settings
 //   builderConfig: builder configuration for a specific input branch
 //
@@ -21,13 +21,13 @@ module.exports = Options
 //   gitUrlPrefix: from builderConfig or top-level config
 //   pagesConfig: from builderConfig or top-level config
 //   pagesYaml: from builderConfig or top-level config
-function Options(info, config, builderConfig) {
+function Options(hook, config, builderConfig) {
   var repoDir = builderConfig.repositoryDir
   var destDir = builderConfig.generatedSiteDir
 
   this.repoDir = path.join(config.home, repoDir)
-  this.repoName = info.repository.name
-  this.sitePath = path.join(config.home, repoDir, info.repository.name)
+  this.repoName = hook.repository.name
+  this.sitePath = path.join(config.home, repoDir, hook.repository.name)
   this.destDir = path.join(config.home, destDir)
   if (builderConfig.internalSiteDir) {
     this.internalDestDir = path.join(

--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,6 @@ function Options(info, config, builderConfig) {
   this.repoDir = path.join(config.home, repoDir)
   this.repoName = info.repository.name
   this.sitePath = path.join(config.home, repoDir, info.repository.name)
-  this.branch = info.ref.split('/').pop()
   this.destDir = path.join(config.home, destDir)
   if (builderConfig.internalSiteDir) {
     this.internalDestDir = path.join(

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -111,24 +111,24 @@ function generateSyncOp(builder, previousSync, buildConfig) {
   })
 }
 
-SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
-  var builderOpts = new Options(info, config, builderConfig),
-      commit = info.head_commit,
+SiteBuilder.launchBuilder = function(hook, branch, builderConfig) {
+  var builderOpts = new Options(hook, config, builderConfig),
       buildLog = builderOpts.sitePath + '.log',
       logger = new BuildLogger(buildLog),
       builder = new SiteBuilder(
-        branch,
-        new ComponentFactory(config, builderOpts, branch, logger)),
+        branch, new ComponentFactory(config, builderOpts, branch, logger)),
       finishBuild,
       migrateLog
 
-  logger.log(info.repository.full_name + ':',
-    'starting build at commit', commit.id)
-  logger.log('description:', commit.message)
-  logger.log('timestamp:', commit.timestamp)
-  logger.log('committer:', commit.committer.email)
-  logger.log('pusher:', info.pusher.name, info.pusher.email)
-  logger.log('sender:', info.sender.login)
+  logger.log(hook.repository.fullName + ':',
+    'starting build at commit', hook.commit.id)
+  logger.log('description:', hook.commit.message)
+  logger.log('timestamp:', hook.commit.timestamp)
+  logger.log('committer:', hook.committer.email)
+
+  if (hook.pusher) {
+    logger.log('pusher:', hook.pusher.name, hook.pusher.email)
+  }
 
   finishBuild = function(err) {
     return new Promise(function(resolve, reject) {

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -10,14 +10,13 @@ exports.parentFromGitUrlPrefix = function(gitUrlPrefix) {
   return gitUrlPrefix.replace(/\/$/, '').split(/[:/]/).pop().toLowerCase()
 }
 
-// Returns a new instance of a webhook implementation object.
+// Returns the specified webhook parser.
 //
 // `webhookType` must match one of the module names in `lib/webhooks`; not case
 // sensitive.
-exports.createImpl = function(webhookType) {
+exports.getParser = function(webhookType) {
   try {
-    var Impl = require('./webhooks/' + (webhookType || 'github').toLowerCase())
-    return new Impl
+    return require('./webhooks/' + (webhookType || 'github').toLowerCase())
   } catch (_) {
     throw new Error('Unknown webhookType: ' + webhookType)
   }
@@ -26,17 +25,17 @@ exports.createImpl = function(webhookType) {
 // Returns a function that builds webhooks matching the configuration
 //
 // Values in `builderConfig` will override default values in `config`.
-exports.createBuilder = function(webhookImpl, config, builderConfig) {
+exports.createBuilder = function(config, builderConfig) {
   var parent = exports.parentFromGitUrlPrefix(
         builderConfig.gitUrlPrefix || config.gitUrlPrefix),
       branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
       branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$')
 
-  return function(hook) {
-    var branch = branchRegexp.exec(webhookImpl.getBranch(hook))
+  return function(parsedHook) {
+    var branch = branchRegexp.exec(parsedHook.branch)
 
-    if (branch && (webhookImpl.getParent(hook) === parent)) {
-      return SiteBuilder.launchBuilder(hook, branch[1], builderConfig)
+    if (branch && parsedHook.parent === parent) {
+      return SiteBuilder.launchBuilder(parsedHook, branch[1], builderConfig)
     } else {
       return Promise.resolve()
     }
@@ -51,26 +50,28 @@ exports.createBuilder = function(webhookImpl, config, builderConfig) {
 //
 // Otherwise `send` will receive a 400 (Bad Request) status, and the function
 // returns an empty resolved Promise.
-exports.handleWebhook = function(hook, impl, builders, send) {
-  if (!impl.isValidWebhook(hook)) {
+exports.handleWebhook = function(hook, parser, builders, send) {
+  var parsed = parser(hook)
+
+  if (parsed === null) {
     send(400)
     return Promise.resolve()
   }
   send(202)
-  return Promise.all(builders.map(builder => builder(hook)))
+  return Promise.all(builders.map(builder => builder(parsed)))
 }
 
 // Returns a (hook, send) that will respond to hooks matching the configuration
 //
-// Instantiates a webhook implementation and generates a list of builders based
-// on `config` for the returned closure.
+// Instantiates a webhook parser and generates a list of builders based on
+// `config` for the returned closure.
 //
 // The `send` argument and returned Promises are identical to those from
 // `handleWebhook`.
 exports.createHandler = function(config) {
-  var impl = exports.createImpl(config.webhookType),
+  var parser = exports.getParser(config.webhookType),
       builders = config.builders.map(builder => {
-        return exports.createBuilder(impl, config, builder)
+        return exports.createBuilder(config, builder)
       })
-  return (hook, send) => exports.handleWebhook(hook, impl, builders, send)
+  return (hook, send) => exports.handleWebhook(hook, parser, builders, send)
 }

--- a/lib/webhooks/bitbucket.js
+++ b/lib/webhooks/bitbucket.js
@@ -2,6 +2,9 @@
 
 module.exports = BitbucketWebhook
 
+// Parses POST service webhooks for Bitbucket Server
+// https://confluence.atlassian.com/bitbucketserver/
+//   post-service-webhook-for-bitbucket-server-776640367.html
 function BitbucketWebhook() {
 }
 
@@ -15,4 +18,40 @@ BitbucketWebhook.prototype.getBranch = function(hook) {
 
 BitbucketWebhook.prototype.getParent = function(hook) {
   return hook.repository.project.key.toLowerCase()
+}
+
+BitbucketWebhook.prototype.parseHook = function(hook) {
+  var refChanges = hook.refChanges,
+      repository = hook.repository,
+      changesets = hook.changesets,
+      repoName,
+      project,
+      commit
+
+  if ([refChanges, repository, changesets].indexOf(undefined) !== -1 ||
+      !changesets.isLastPage) {
+    return null
+  }
+
+  repoName = repository.slug
+  project = repository.project.key.toLowerCase()
+  commit = changesets.values[0].toCommit
+
+  return {
+    branch: refChanges[0].refId,
+    parent: project,
+    repository: {
+      name: repoName,
+      fullName: project + '/' + repoName
+    },
+    commit: {
+      id: commit.id,
+      messsage: commit.message,
+      timestamp: commit.authorTimestamp
+    },
+    committer: {
+      name: commit.author.name,
+      email: commit.author.emailAddress
+    }
+  }
 }

--- a/lib/webhooks/bitbucket.js
+++ b/lib/webhooks/bitbucket.js
@@ -1,26 +1,9 @@
 'use strict'
 
-module.exports = BitbucketWebhook
-
 // Parses POST service webhooks for Bitbucket Server
 // https://confluence.atlassian.com/bitbucketserver/
 //   post-service-webhook-for-bitbucket-server-776640367.html
-function BitbucketWebhook() {
-}
-
-BitbucketWebhook.prototype.isValidWebhook = function(hook) {
-  return hook.refChanges !== undefined
-}
-
-BitbucketWebhook.prototype.getBranch = function(hook) {
-  return hook.refChanges[0].refId
-}
-
-BitbucketWebhook.prototype.getParent = function(hook) {
-  return hook.repository.project.key.toLowerCase()
-}
-
-BitbucketWebhook.prototype.parseHook = function(hook) {
+module.exports = function(hook) {
   var refChanges = hook.refChanges,
       repository = hook.repository,
       changesets = hook.changesets,
@@ -46,7 +29,7 @@ BitbucketWebhook.prototype.parseHook = function(hook) {
     },
     commit: {
       id: commit.id,
-      messsage: commit.message,
+      message: commit.message,
       timestamp: commit.authorTimestamp
     },
     committer: {

--- a/lib/webhooks/github.js
+++ b/lib/webhooks/github.js
@@ -1,25 +1,8 @@
 'use strict'
 
-module.exports = GitHubWebhook
-
 // Parses GitHub webhooks and parses them into a common format
 // https://developer.github.com/v3/activity/events/types/#pushevent
-function GitHubWebhook() {
-}
-
-GitHubWebhook.prototype.isValidWebhook = function(hook) {
-  return hook.repository !== undefined
-}
-
-GitHubWebhook.prototype.getBranch = function(hook) {
-  return hook.ref
-}
-
-GitHubWebhook.prototype.getParent = function(hook) {
-  return hook.repository.organization
-}
-
-GitHubWebhook.prototype.parseHook = function(hook) {
+module.exports = function(hook) {
   var branch = hook.ref,
       repository = hook.repository,
       commit = hook.head_commit,
@@ -38,7 +21,7 @@ GitHubWebhook.prototype.parseHook = function(hook) {
     },
     commit: {
       id: commit.id,
-      messsage: commit.message,
+      message: commit.message,
       timestamp: commit.timestamp
     },
     committer: {

--- a/lib/webhooks/github.js
+++ b/lib/webhooks/github.js
@@ -2,6 +2,8 @@
 
 module.exports = GitHubWebhook
 
+// Parses GitHub webhooks and parses them into a common format
+// https://developer.github.com/v3/activity/events/types/#pushevent
 function GitHubWebhook() {
 }
 
@@ -15,4 +17,37 @@ GitHubWebhook.prototype.getBranch = function(hook) {
 
 GitHubWebhook.prototype.getParent = function(hook) {
   return hook.repository.organization
+}
+
+GitHubWebhook.prototype.parseHook = function(hook) {
+  var branch = hook.ref,
+      repository = hook.repository,
+      commit = hook.head_commit,
+      pusher = hook.pusher
+
+  if ([branch, repository, commit, pusher].indexOf(undefined) !== -1) {
+    return null
+  }
+
+  return {
+    branch: branch,
+    parent: repository.organization,
+    repository: {
+      name: repository.name,
+      fullName: repository.full_name
+    },
+    commit: {
+      id: commit.id,
+      messsage: commit.message,
+      timestamp: commit.timestamp
+    },
+    committer: {
+      name: commit.committer.name,
+      email: commit.committer.email
+    },
+    pusher: {
+      name: hook.pusher.name,
+      email: hook.pusher.email
+    }
+  }
 }

--- a/pages-config.json
+++ b/pages-config.json
@@ -12,6 +12,7 @@
     "bucket":  "s3://pages"
   },
   "payloadLimit":     1048576,
+  "webhookType":      "github",
   "gitUrlPrefix":     "git@github.com:mbland",
   "pagesConfig":      "_config_pages.yml",
   "pagesYaml":        ".pages.yml",

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -35,7 +35,6 @@ describe('Options', function() {
     expect(opts.repoName).to.equal('repo_name')
     expect(opts.sitePath).to.equal(
       path.join(config.home, 'repo_dir/repo_name'))
-    expect(opts.branch).to.equal('mbland-pages')
     expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'))
     expect(opts.internalDestDir).to.be.undefined
     expect(opts.gitUrlPrefix).to.equal('git@github.com:mbland/')
@@ -66,7 +65,6 @@ describe('Options', function() {
     expect(opts.repoName).to.equal('repo_name')
     expect(opts.sitePath).to.equal(
       path.join(config.home, 'repo_dir/repo_name'))
-    expect(opts.branch).to.equal('foobar-pages')
     expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'))
     expect(opts.internalDestDir).to.be.undefined
     expect(opts.gitUrlPrefix).to.equal('git@github.com:foobar/')

--- a/test/webhooks/bitbucket.json
+++ b/test/webhooks/bitbucket.json
@@ -1,0 +1,29 @@
+{
+  "repository": {
+    "slug": "pages-server",
+    "project": {
+      "key": "MBLAND"
+    }
+  },
+  "refChanges": [
+    {
+      "refId": "refs/heads/pages"
+    }
+  ],
+  "changesets": {
+    "isLastPage": true,
+    "values": [
+      {
+        "toCommit": {
+          "id": "deadbeef",
+          "author": {
+            "name": "mbland",
+            "emailAddress": "mbland@acm.org"
+          },
+          "authorTimestamp": "2017-10-27",
+          "message": "Build me"
+        }
+      }
+    ]
+  }
+}

--- a/test/webhooks/github.json
+++ b/test/webhooks/github.json
@@ -1,0 +1,21 @@
+{
+  "ref": "refs/heads/pages",
+  "repository": {
+    "organization": "mbland",
+    "name": "pages-server",
+    "full_name": "mbland/pages-server"
+  },
+  "head_commit": {
+    "id": "deadbeef",
+    "message": "Build me",
+    "timestamp": "2017-10-27",
+    "committer": {
+      "name": "mbland",
+      "email": "mbland@acm.org"
+    }
+  },
+  "pusher": {
+    "name": "mbland",
+    "email": "mbland@acm.org"
+  }
+}

--- a/test/webhooks/parsed.json
+++ b/test/webhooks/parsed.json
@@ -1,0 +1,21 @@
+{
+  "branch": "refs/heads/pages",
+  "parent": "mbland",
+  "repository": {
+    "name": "pages-server",
+    "fullName": "mbland/pages-server"
+  },
+  "commit": {
+    "id": "deadbeef",
+    "message": "Build me",
+    "timestamp": "2017-10-27"
+  },
+  "committer": {
+    "name": "mbland",
+    "email": "mbland@acm.org"
+  },
+  "pusher": {
+    "name": "mbland",
+    "email": "mbland@acm.org"
+  }
+}


### PR DESCRIPTION
Closes #2. Turned out that #15 and #16 didn't do enough to ensure Bitbucket compatibility. Now a single function parses each of the GitHub and Bitbucket webhook formats into a single common format, and that format is propagated throughout the system.