### PR TITLE
Dockerfile: Install ruby via apk on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,13 @@
-FROM node:8.8.1-slim
+FROM node:8.8.1-alpine
 MAINTAINER Mike Bland "mbland@acm.org"
 
-ENV RBENV_ROOT /opt/rbenv
-RUN apt update && apt install -y \
-    bash \
-    build-essential \
-    curl \
-    git \
-    jq \
-    libreadline-dev \
-    libssl-dev \
-    libyaml-dev \
-    rsync \
-    wget \
-    zlib1g-dev && \
-  git clone https://github.com/rbenv/rbenv.git "$RBENV_ROOT" && \
-  echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >>"/etc/profile.d/rbenv.sh" && \
-  echo 'eval "$(rbenv init -)"' >>"/etc/profile.d/rbenv.sh" && \
-  git clone https://github.com/rbenv/ruby-build.git \
-    "$RBENV_ROOT/plugins/ruby-build" && \
-  "$RBENV_ROOT/bin/rbenv" install 2.4.2 && \
-  echo "gem: --no-ri --no-rdoc" > /etc/gemrc && \
-  . "/etc/profile.d/rbenv.sh" && \
-  rbenv global 2.4.2 && \
-  gem install bundler colorator jekyll
+RUN apk update && \
+    apk upgrade && \
+    apk add ruby ruby-bundler libffi && \
+    apk add --no-cache --virtual .build-deps build-base ruby-dev libffi-dev && \
+    echo "gem: --no-ri --no-rdoc" > /etc/gemrc && \
+    gem install bundler colorator jekyll && \
+    apk del .build-deps
 
 WORKDIR /opt/pages-server
 COPY package.json package-lock.json ./
@@ -31,5 +15,4 @@ RUN npm install --production
 COPY . ./
 
 EXPOSE 5000
-ENV PATH "$RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH"
 CMD [ "/opt/pages-server/bin/pages-server", "/etc/pages-server.conf" ]


### PR DESCRIPTION
It turned out that building the latest ruby via rbenv isn't necessary after all, because the ruby packages on Alpine are up-to-date. This takes 530MB off of the resulting image size.