### PR TITLE
webhooks: Parse authorTimestamp into locale string

### DIFF
--- a/lib/webhooks/bitbucket.js
+++ b/lib/webhooks/bitbucket.js
@@ -15,7 +15,7 @@ module.exports = function(hook) {
     return null
   }
   commit = changesets.values[0].toCommit
-  timestamp = new Date(parseInt(commit.authorTimestamp))
+  timestamp = new Date(commit.authorTimestamp)
 
   return {
     branch: refChanges[0].refId,

--- a/lib/webhooks/bitbucket.js
+++ b/lib/webhooks/bitbucket.js
@@ -7,13 +7,15 @@ module.exports = function(hook) {
   var refChanges = hook.refChanges,
       repository = hook.repository,
       changesets = hook.changesets,
-      commit
+      commit,
+      timestamp
 
   if ([refChanges, repository, changesets].indexOf(undefined) !== -1 ||
       !changesets.isLastPage) {
     return null
   }
   commit = changesets.values[0].toCommit
+  timestamp = new Date(parseInt(commit.authorTimestamp))
 
   return {
     branch: refChanges[0].refId,
@@ -22,7 +24,7 @@ module.exports = function(hook) {
     commit: {
       id: commit.id,
       message: commit.message,
-      timestamp: commit.authorTimestamp
+      timestamp: timestamp.toLocaleString()
     },
     author: {
       name: commit.author.name,

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -257,7 +257,7 @@ describe('SiteBuilder', function() {
           var expectedMessages = [
                 'mbland/pages-server: starting build at commit deadbeef',
                 'description: Build me',
-                'timestamp: 2017-10-27',
+                'timestamp: 2017-10-29 16:37:01',
                 'author: mbland mbland@acm.org',
                 'committer: mbland mbland@acm.org',
                 'pusher: mbland mbland@acm.org',
@@ -289,7 +289,7 @@ describe('SiteBuilder', function() {
           var expectedMessages = [
                 'mbland/pages-server: starting build at commit deadbeef',
                 'description: Build me',
-                'timestamp: 2017-10-27',
+                'timestamp: 2017-10-29 16:37:01',
                 'author: mbland mbland@acm.org',
                 'committer: mbland mbland@acm.org',
                 'pusher: mbland mbland@acm.org',

--- a/test/webhooks-test.js
+++ b/test/webhooks-test.js
@@ -57,9 +57,13 @@ describe('Webhooks', function() {
 
   describe('Bitbucket parser', function() {
     it('should parse a valid webhook', function() {
-      var expectedHook = cloneJson(parsedHook)
+      var expectedHook = cloneJson(parsedHook),
+          toCommit = bitbucketHook.changesets.values[0].toCommit,
+          timestamp = new Date(toCommit.authorTimestamp)
+
       delete expectedHook.committer
       delete expectedHook.pusher
+      expectedHook.commit.timestamp = timestamp.toLocaleString()
       bitbucketParser(bitbucketHook).should.deep.eql(expectedHook)
     })
 

--- a/test/webhooks/bitbucket.json
+++ b/test/webhooks/bitbucket.json
@@ -20,7 +20,7 @@
             "name": "mbland",
             "emailAddress": "mbland@acm.org"
           },
-          "authorTimestamp": "2017-10-27",
+          "authorTimestamp": 1509309421008,
           "message": "Build me"
         }
       }

--- a/test/webhooks/github.json
+++ b/test/webhooks/github.json
@@ -8,7 +8,7 @@
   "head_commit": {
     "id": "deadbeef",
     "message": "Build me",
-    "timestamp": "2017-10-27",
+    "timestamp": "2017-10-29 16:37:01",
     "author": {
       "name": "mbland",
       "email": "mbland@acm.org"

--- a/test/webhooks/parsed.json
+++ b/test/webhooks/parsed.json
@@ -5,7 +5,7 @@
   "commit": {
     "id": "deadbeef",
     "message": "Build me",
-    "timestamp": "2017-10-27"
+    "timestamp": "2017-10-29 16:37:01"
   },
   "author": {
     "name": "mbland",


### PR DESCRIPTION
The unparsed, integer value was causing `writeToLogFile` in `lib/build-logger.js` to throw an error.